### PR TITLE
fix: bin/run is not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 /.ethstatedb*
 /.nyc_output
 /.test-data
-/bin
 /dist
 /lib
 /tmp

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+require('@oclif/command').run()
+.then(require('@oclif/command/flush'))
+.catch(require('@oclif/errors/handle'))

--- a/bin/run.cmd
+++ b/bin/run.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+node "%~dp0\run" %*


### PR DESCRIPTION
When testing on a fresh server, error is reported as

```
4872 error path /Users/shenghu/.nvm/versions/node/v10.15.3/lib/node_modules/ethstatedb/bin/run
4873 error code ENOENT
4874 error errno -2
4875 error syscall chmod
4876 error enoent ENOENT: no such file or directory, chmod '/Users/shenghu/.nvm/versions/node/v10.15.3/lib/node_modules/ethstatedb/bin/run'
4877 error enoent This is related to npm not being able to find a file.
4878 verbose exit [ -2, true ]
```